### PR TITLE
filter soul speed from imbuing

### DIFF
--- a/src/main/java/me/sandbox/util/ImbueUtil.java
+++ b/src/main/java/me/sandbox/util/ImbueUtil.java
@@ -15,6 +15,7 @@ public class ImbueUtil {
         enchants.add("enchantment.minecraft.mending");
         enchants.add("enchantment.minecraft.multishot");
         enchants.add("enchantment.minecraft.silk_touch");
+        enchants.add("enchantment.minecraft.soul_speed");
 
         return enchants;
     }


### PR DESCRIPTION
Soul speed goes so fast past max level that it crashes you out, so we probably shouldn't allow it