### PR TITLE
Fixed CleverNucleus/data-attributes #93

### DIFF
--- a/src/main/java/me/sandbox/entity/AlchemistEntity.java
+++ b/src/main/java/me/sandbox/entity/AlchemistEntity.java
@@ -48,7 +48,7 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.ai.goal.SwimGoal;
 import net.minecraft.world.World;
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.data.TrackedData;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.mob.IllagerEntity;
@@ -60,7 +60,6 @@ public class AlchemistEntity extends IllagerEntity implements RangedAttackMob
     public boolean inPotionState;
     public boolean inBowState;
     public int potionCooldown;
-    private AttributeContainer attributeContainer;
 
     public AlchemistEntity(final EntityType<? extends AlchemistEntity> entityType, final World world) {
         super(entityType, world);
@@ -83,12 +82,9 @@ public class AlchemistEntity extends IllagerEntity implements RangedAttackMob
         this.targetSelector.add(3, new ActiveTargetGoal(this, IronGolemEntity.class, false));
     }
 
-    public AttributeContainer getAttributes() {
-        if (this.attributeContainer == null) {
-            this.attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 23.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38).build());
-        }
-        return this.attributeContainer;
-    }
+	public static DefaultAttributeContainer.Builder createAlchemistAttributes() {
+		return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 23.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38);
+	}
 
     public EntityData initialize(final ServerWorldAccess world, final LocalDifficulty difficulty, final SpawnReason spawnReason, @Nullable final EntityData entityData, @Nullable final NbtCompound entityNbt) {
         this.equipStack(EquipmentSlot.MAINHAND, new ItemStack((ItemConvertible)Items.BOW));

--- a/src/main/java/me/sandbox/entity/ArchivistEntity.java
+++ b/src/main/java/me/sandbox/entity/ArchivistEntity.java
@@ -6,7 +6,7 @@ import me.sandbox.util.spellutil.EnchantToolUtil;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.*;
@@ -59,17 +59,11 @@ public class ArchivistEntity
         this.targetSelector.add(3, new ActiveTargetGoal<MerchantEntity>((MobEntity)this, MerchantEntity.class, false).setMaxTimeWithoutVisibility(300));
         this.targetSelector.add(3, new ActiveTargetGoal<IronGolemEntity>((MobEntity)this, IronGolemEntity.class, false));
     }
-    private AttributeContainer attributeContainer;
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+    public static DefaultAttributeContainer.Builder createArchivistAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 22.0D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.36D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.36D);
+	}
 
     @Override
     protected void initDataTracker() {

--- a/src/main/java/me/sandbox/entity/BasherEntity.java
+++ b/src/main/java/me/sandbox/entity/BasherEntity.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.*;
 import net.minecraft.entity.ai.NavigationConditions;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.ai.pathing.MobNavigation;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.damage.DamageSource;
@@ -134,25 +134,19 @@ public class BasherEntity
             }
         }
     }
-    private AttributeContainer attributeContainer;
 
     @Override
     protected boolean isImmobile() {
         return super.isImmobile() || this.getStunnedState();
     }
 
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+	public static DefaultAttributeContainer.Builder createBasherAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 28.0D)
                     .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.31D)
                     .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.0D)
-                    .add(EntityAttributes.GENERIC_ATTACK_KNOCKBACK,0.2D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_ATTACK_KNOCKBACK,0.2D);
+	}
 
 
     @Override

--- a/src/main/java/me/sandbox/entity/EntityRegistry.java
+++ b/src/main/java/me/sandbox/entity/EntityRegistry.java
@@ -3,6 +3,7 @@ package me.sandbox.entity;
 import me.sandbox.IllagerExpansion;
 import me.sandbox.entity.projectile.HatchetEntity;
 import me.sandbox.entity.projectile.MagmaEntity;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.minecraft.entity.*;
 import net.minecraft.util.Identifier;
@@ -53,6 +54,16 @@ public class EntityRegistry {
     );
 
     public static void registerEntities() {
+		FabricDefaultAttributeRegistry.register(ALCHEMIST, AlchemistEntity.createAlchemistAttributes());
+		FabricDefaultAttributeRegistry.register(ARCHIVIST, ArchivistEntity.createArchivistAttributes());
+		FabricDefaultAttributeRegistry.register(BASHER, BasherEntity.createBasherAttributes());
+		FabricDefaultAttributeRegistry.register(FIRECALLER, FirecallerEntity.createFirecallerAttributes());
+		FabricDefaultAttributeRegistry.register(INQUISITOR, InquisitorEntity.createInquisitorAttributes());
+		FabricDefaultAttributeRegistry.register(INVOKER, InvokerEntity.createInvokerAttributes());
+		FabricDefaultAttributeRegistry.register(MARAUDER, MarauderEntity.createMaurauderAttributes());
+		FabricDefaultAttributeRegistry.register(PROVOKER, ProvokerEntity.createProvokerAttributes());
+		FabricDefaultAttributeRegistry.register(SORCERER, SorcererEntity.createSorcererAttributes());
+		FabricDefaultAttributeRegistry.register(SURRENDERED, SurrenderedEntity.createSurrenderedAttributes());
     }
 
 }

--- a/src/main/java/me/sandbox/entity/FirecallerEntity.java
+++ b/src/main/java/me/sandbox/entity/FirecallerEntity.java
@@ -12,7 +12,7 @@ import net.minecraft.client.render.entity.feature.SkinOverlayOwner;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.data.DataTracker;
@@ -46,7 +46,6 @@ public class FirecallerEntity extends SpellcastingIllagerEntity
     private SheepEntity wololoTarget;
     private int cooldown = 160;
     private int aoecooldown = 300;
-    private AttributeContainer attributeContainer;
 
     public FirecallerEntity(final EntityType<? extends FirecallerEntity> entityType, final World world) {
         super(entityType, world);
@@ -70,12 +69,9 @@ public class FirecallerEntity extends SpellcastingIllagerEntity
 
     }
 
-    public AttributeContainer getAttributes() {
-        if (this.attributeContainer == null) {
-            this.attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 32.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38).build());
-        }
-        return this.attributeContainer;
-    }
+	public static DefaultAttributeContainer.Builder createFirecallerAttributes() {
+		return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 32.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38);
+	}
 
     protected void initDataTracker() {
         super.initDataTracker();

--- a/src/main/java/me/sandbox/entity/InquisitorEntity.java
+++ b/src/main/java/me/sandbox/entity/InquisitorEntity.java
@@ -54,7 +54,7 @@ import net.minecraft.entity.passive.MerchantEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.raid.RaiderEntity;
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.data.TrackedData;
 import net.minecraft.item.Item;
 import java.util.Set;
@@ -68,7 +68,6 @@ public class InquisitorEntity extends IllagerEntity
     public static final Set<Item> AXES;
     private static final TrackedData<Boolean> STUNNED = DataTracker.registerData(InquisitorEntity.class, TrackedDataHandlerRegistry.BOOLEAN);
     private static final TrackedData<Boolean> FINAL_ROAR = DataTracker.registerData(InquisitorEntity.class, TrackedDataHandlerRegistry.BOOLEAN);
-    private AttributeContainer attributeContainer;
     static {
         AXES = Sets.newHashSet(Items.DIAMOND_AXE, Items.STONE_AXE, Items.IRON_AXE, Items.NETHERITE_AXE, Items.WOODEN_AXE, Items.GOLDEN_AXE, ItemRegistry.PLATINUM_INFUSED_NETHERITE_AXE);
     }
@@ -103,12 +102,9 @@ public class InquisitorEntity extends IllagerEntity
         super.mobTick();
     }
 
-    public AttributeContainer getAttributes() {
-        if (this.attributeContainer == null) {
-            this.attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 80.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.33).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 10.0).add(EntityAttributes.GENERIC_ATTACK_KNOCKBACK, 1.6).add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 0.8).build());
-        }
-        return this.attributeContainer;
-    }
+	public static DefaultAttributeContainer.Builder createInquisitorAttributes() {
+		return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 80.0).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.33).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 10.0).add(EntityAttributes.GENERIC_ATTACK_KNOCKBACK, 1.6).add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 0.8);
+	}
 
     public void tickMovement() {
         if (this.horizontalCollision && this.world.getGameRules().getBoolean(GameRules.DO_MOB_GRIEFING)) {

--- a/src/main/java/me/sandbox/entity/InvokerEntity.java
+++ b/src/main/java/me/sandbox/entity/InvokerEntity.java
@@ -14,7 +14,7 @@ import net.minecraft.client.render.entity.feature.SkinOverlayOwner;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.boss.BossBar;
 import net.minecraft.entity.boss.ServerBossBar;
@@ -100,20 +100,14 @@ public class InvokerEntity
         return this.getShieldedState();
     }
 
-    private AttributeContainer attributeContainer;
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+	public static DefaultAttributeContainer.Builder createInvokerAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 250.0D)
                     .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.36D)
                     .add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 0.3D)
-                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 8.0D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 8.0D);
+	}
+
     @Override
     public boolean tryAttack(Entity target) {
         if (!super.tryAttack(target)) {

--- a/src/main/java/me/sandbox/entity/MarauderEntity.java
+++ b/src/main/java/me/sandbox/entity/MarauderEntity.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.*;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.data.DataTracker;
@@ -49,18 +50,11 @@ public class MarauderEntity
         this.targetSelector.add(3, new ActiveTargetGoal<IronGolemEntity>((MobEntity) this, IronGolemEntity.class, false));
     }
 
-    private AttributeContainer attributeContainer;
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+	public static DefaultAttributeContainer.Builder createMaurauderAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 21.0D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.30D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.30D);
+	}
 
     public boolean isCharging() {
         return this.dataTracker.get(CHARGING);

--- a/src/main/java/me/sandbox/entity/ProvokerEntity.java
+++ b/src/main/java/me/sandbox/entity/ProvokerEntity.java
@@ -5,7 +5,7 @@ import me.sandbox.sounds.SoundRegistry;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -57,17 +57,11 @@ public class ProvokerEntity
         this.targetSelector.add(3, new ActiveTargetGoal<MerchantEntity>((MobEntity)this, MerchantEntity.class, false).setMaxTimeWithoutVisibility(300));
         this.targetSelector.add(3, new ActiveTargetGoal<IronGolemEntity>((MobEntity)this, IronGolemEntity.class, false));
     }
-    private AttributeContainer attributeContainer;
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+    public static DefaultAttributeContainer.Builder createProvokerAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 23.0D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38D);
+	}
     @Override
     public EntityData initialize(ServerWorldAccess world, LocalDifficulty difficulty, SpawnReason spawnReason, @Nullable EntityData entityData, @Nullable NbtCompound entityNbt) {
         this.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Items.BOW));

--- a/src/main/java/me/sandbox/entity/SorcererEntity.java
+++ b/src/main/java/me/sandbox/entity/SorcererEntity.java
@@ -11,7 +11,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffect;
@@ -69,17 +69,11 @@ public class SorcererEntity
         this.targetSelector.add(3, new ActiveTargetGoal<MerchantEntity>((MobEntity)this, MerchantEntity.class, false).setMaxTimeWithoutVisibility(300));
         this.targetSelector.add(3, new ActiveTargetGoal<IronGolemEntity>((MobEntity)this, IronGolemEntity.class, false));
     }
-    private AttributeContainer attributeContainer;
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+    public static DefaultAttributeContainer.Builder createSorcererAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 26.0D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.38D);
+	}
 
     @Override
     protected void initDataTracker() {

--- a/src/main/java/me/sandbox/entity/SurrenderedEntity.java
+++ b/src/main/java/me/sandbox/entity/SurrenderedEntity.java
@@ -7,7 +7,6 @@ import net.minecraft.entity.*;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.control.MoveControl;
 import net.minecraft.entity.ai.goal.*;
-import net.minecraft.entity.attribute.AttributeContainer;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
@@ -86,18 +85,11 @@ public class SurrenderedEntity extends SkeletonEntity {
         this.targetSelector.add(3, new ActiveTargetGoal<PlayerEntity>((MobEntity)this, PlayerEntity.class, true));
     }
 
-    private AttributeContainer attributeContainer;
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
+    public static DefaultAttributeContainer.Builder createSurrenderedAttributes() {
+		return HostileEntity.createHostileAttributes()
                     .add(EntityAttributes.GENERIC_MAX_HEALTH, 18.0D)
-                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE,5.0D)
-                    .build());
-        }
-        return attributeContainer;
-    }
+                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE,5.0D);
+	}
     @Override
     public boolean handleFallDamage(float fallDistance, float damageMultiplier, DamageSource damageSource) {
         return false;


### PR DESCRIPTION
### 1.0 Changes

Replaced unorthodox method of initialising entity attributes using null assignment with conventional fabric supported method. Affects entity classes within `me.sandbox.entity`.

### 2.0 Reasons

See [#93](https://github.com/CleverNucleus/data-attributes/issues/93).